### PR TITLE
DMP-1467_Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
 	implementation 'org.apache.logging.log4j:log4j-core'
 	testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl'
 	
-	implementation 'org.seleniumhq.selenium:selenium-java:4.16.0'
+	implementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
 	
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
 	


### PR DESCRIPTION
## Change description ###
Downgrade selenium from 4.16.0 to 4.15.0 as a dependency is missing & so build breaks


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
