### PR TITLE
Fixes for nightly run

### DIFF
--- a/src/test/resources/cucumber/features/endtoend/DARTS_End_to_End_AdvanceSearch.feature
+++ b/src/test/resources/cucumber/features/endtoend/DARTS_End_to_End_AdvanceSearch.feature
@@ -3,7 +3,7 @@ Feature: Advance Search
   @end2end @end2end6 @DMP-1927
    #Created a case and event via Post courtlog
   Scenario Outline: Create a case
-    Given I authenticate from the DARMIDTIER source system
+    #Given I authenticate from the DARMIDTIER source system
     Given I create a case
       | courthouse   | case_number   | defendants   | judges   | prosecutors   | defenders   |
       | <courthouse> | <case_number> | <defendants> | <judges> | <prosecutors> | <defenders> |
@@ -135,7 +135,7 @@ Feature: Advance Search
     Given I create an event
       | message_id   | type   | sub_type  | event_id  | courthouse   | courtroom   | case_numbers  | event_text | date_time  | case_retention_fixed_policy | case_total_sentence |
       | <message_id> | <type> | <subType> | <eventId> | <courthouse> | <courtroom> | <case_number> | <keywords> | <dateTime> | <caseRetention>             | <totalSentence>     |
-    Given I authenticate from the DARMIDTIER source system
+    #Given I authenticate from the DARMIDTIER source system
     Given I create a case
       | courthouse   | case_number   | defendants   | judges   | prosecutors   | defenders   |
       | <courthouse> | <case_number> | <defendants> | <judges> | <prosecutors> | <defenders> |

--- a/src/test/resources/cucumber/features/portal/DARTS_Case_Search.feature
+++ b/src/test/resources/cucumber/features/portal/DARTS_Case_Search.feature
@@ -4,7 +4,7 @@ Feature: Case Search
 
 @DMP-509 @DMP-507 @DMP-508 @DMP-517 @DMP-515 @DMP-860 @DMP-702 @DMP-561 @DMP-963 @DMP-997 @regression
 Scenario: Case Search data creation
-	Given I create a case using json
+	Given I create a case
 		| courthouse         | case_number | defendants     | judges           | prosecutors         | defenders         |
 		| Harrow Crown Court | A{{seq}}001 | Def {{seq}}-1  | Judge {{seq}}-1  | testprosecutor      | testdefender      |
 		| Harrow Crown Court | A{{seq}}002 | Def {{seq}}-11 | Judge {{seq}}-11 | testprosecutortwo   | testdefendertwo   |
@@ -12,7 +12,7 @@ Scenario: Case Search data creation
 		| Harrow Crown Court | A{{seq}}004 | Def {{seq}}-22 | Judge {{seq}}-2  | testprosecutorfour  | testdefenderfour  |
 		| Harrow Crown Court | A{{seq}}005 | Def {{seq}}-11 | Judge {{seq}}-2  | testprosecutorfive  | testdefenderfive  |
 
-	Given I create an event using json
+	Given I create an event
 		| message_id | type  | sub_type | event_id    | courthouse         | courtroom  | case_numbers | event_text    | date_time              | case_retention_fixed_policy | case_total_sentence |
 		| {{seq}}001 | 1100  |          | {{seq}}1001 | Harrow Crown Court | {{seq}}-1  | A{{seq}}001  | {{seq}}ABC-1  | {{timestamp-10:00:00}} |                             |                     |
 		| {{seq}}001 | 1100  |          | {{seq}}1001 | Harrow Crown Court | {{seq}}-11 | A{{seq}}002  | {{seq}}ABC-2  | {{timestamp-10:00:00}} |                             |                     |

--- a/src/test/resources/cucumber/features/portal/DARTS_Request_Audio.feature
+++ b/src/test/resources/cucumber/features/portal/DARTS_Request_Audio.feature
@@ -6,20 +6,20 @@ Scenario: Request Audio data creation
 
   Given I create a case
     | courthouse         | case_number | defendants    | judges          | prosecutors         | defenders         |
-    | Harrow Crown Court | A{{seq}}006 | Def {{seq}}-1 | Judge {{seq}}-1 | testprosecutorsix   | testdefendersix   |
-    | Harrow Crown Court | A{{seq}}007 | Def {{seq}}-7 | Judge {{seq}}-7 | testprosecutorseven | testdefenderseven |
+    | Harrow Crown Court | B{{seq}}006 | Def {{seq}}-6 | Judge {{seq}}-6 | testprosecutorsix   | testdefendersix   |
+    | Harrow Crown Court | B{{seq}}007 | Def {{seq}}-7 | Judge {{seq}}-7 | testprosecutorseven | testdefenderseven |
 
   Given I create an event
     | message_id | type | sub_type | event_id    | courthouse         | courtroom  | case_numbers | event_text    | date_time              | case_retention_fixed_policy | case_total_sentence |
-    | {{seq}}001 | 1100 | 	     | {{seq}}1001 | Harrow Crown Court | {{seq}}-6  | A{{seq}}006  | {{seq}}ABC-6  | {{timestamp-10:00:00}} |                             |                     |
-    | {{seq}}002 | 1100 | 	     | {{seq}}1002 | Harrow Crown Court | {{seq}}-7  | A{{seq}}007  | {{seq}}ABC-7  | {{timestamp-10:00:00}} |                             |                     |
+    | {{seq}}006 | 1100 | 	     | {{seq}}1006 | Harrow Crown Court | {{seq}}-6  | B{{seq}}006  | {{seq}}ABC-6  | {{timestamp-10:00:00}} |                             |                     |
+    | {{seq}}007 | 1100 | 	     | {{seq}}1007 | Harrow Crown Court | {{seq}}-7  | B{{seq}}007  | {{seq}}ABC-7  | {{timestamp-10:00:00}} |                             |                     |
 
-  When I authenticate from the darmidtier source system
+  #When I authenticate from the darmidtier source system
 
   When I load an audio file
     | courthouse         | courtroom | case_numbers | date        | startTime | endTime  | audioFile |
-    | Harrow Crown Court | {{seq}}-6 | A{{seq}}006  | {{date+0/}} | 10:01:00  | 10:02:00 | sample1   |
-    | Harrow Crown Court | {{seq}}-7 | A{{seq}}007  | {{date+0/}} | 10:01:00  | 10:02:00 | sample1   |
+    | Harrow Crown Court | {{seq}}-6 | B{{seq}}006  | {{date+0/}} | 10:01:00  | 10:02:00 | sample1   |
+    | Harrow Crown Court | {{seq}}-7 | B{{seq}}007  | {{date+0/}} | 10:01:00  | 10:02:00 | sample1   |
 
 @DMP-685 @DMP-651 @DMP-658 @DMP-696 @DMP-695 @DMP-686 @regression
 Scenario: Request Audio with Request Type Playback Only NEW
@@ -27,15 +27,15 @@ Scenario: Request Audio with Request Type Playback Only NEW
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
   And I see "Search for a case" on the page
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
   Then I verify the HTML table contains the following values
     | Case ID     | Courthouse         | Courtroom | Judge(s)        | Defendants(s) |
-    | A{{seq}}006 | Harrow Crown Court | {{seq}}-6 | Judge {{seq}}-1 | Def {{seq}}-1 |
+    | B{{seq}}006 | Harrow Crown Court | {{seq}}-6 | Judge {{seq}}-6 | Def {{seq}}-6 |
 
   #Case Details
 
-  When I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  When I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
 
   #Hearing Details
 
@@ -52,9 +52,9 @@ Scenario: Request Audio with Request Type Playback Only NEW
   Then I see "Confirm your Order" on the page
   #And I see "<Restriction>" on the page
   And I see "Case details" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "Audio details" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
@@ -65,9 +65,9 @@ Scenario: Request Audio with Request Type Playback Only NEW
   When I press the "Confirm" button
   Then I see "Your order is complete" on the page
   #And I see "<Restriction>" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
   And I see "10:02:00" on the page
@@ -80,15 +80,15 @@ Scenario: Request Audio with Request Type Download NEW
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
   And I see "Search for a case" on the page
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
   Then I verify the HTML table contains the following values
     | Case ID     | Courthouse         | Courtroom | Judge(s)        | Defendants(s) |
-    | A{{seq}}006 | Harrow Crown Court | {{seq}}-6 | Judge {{seq}}-1 | Def {{seq}}-1 |
+    | B{{seq}}006 | Harrow Crown Court | {{seq}}-6 | Judge {{seq}}-6 | Def {{seq}}-6 |
 
   #Case Details
 
-  When I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  When I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
 
   #Hearing Details
 
@@ -105,9 +105,9 @@ Scenario: Request Audio with Request Type Download NEW
   Then I see "Confirm your Order" on the page
   #And I see "<Restriction>" on the page
   And I see "Case details" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "Audio details" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
@@ -118,9 +118,9 @@ Scenario: Request Audio with Request Type Download NEW
   When I press the "Confirm" button
   Then I see "Your order is complete" on the page
   #And I see "<Restriction>" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
   And I see "10:02:00" on the page
@@ -131,9 +131,9 @@ Scenario: Request Audio with Request Type Download NEW
 Scenario: Request Audio Confirm your Order Cancel link
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -149,9 +149,9 @@ Scenario: Request Audio Confirm your Order Cancel link
 Scenario: Request Audio Confirm Order Back link
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -167,9 +167,9 @@ Scenario: Request Audio Confirm Order Back link
 Scenario: Request Audio Error Messages
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -182,9 +182,9 @@ Scenario: Request Audio Error Messages
 Scenario: Request Audio request type error message
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -197,9 +197,9 @@ Scenario: Request Audio request type error message
 Scenario: Order Confirmation - Return to hearing date link
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -218,9 +218,9 @@ Scenario: Order Confirmation - Return to hearing date link
 Scenario: Order Confirmation - Back to search results link
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}007"
+  And I set "Case ID" to "B{{seq}}007"
   And I press the "Search" button
-  And I click on "A{{seq}}007" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}007" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-7"
   Then I see "{{seq}}ABC-7" on the page
 
@@ -235,13 +235,13 @@ Scenario: Order Confirmation - Back to search results link
   And I click on the "Back to search results" link
   Then I see "Search for a case" on the page
 
-@DMP-695 @regression  #Manually enter in Start Time and End Time
+@DMP-695 @regression #Manually enter in Start Time and End Time
 Scenario: Request Audio by setting Start Time and End Time
   Given I am logged on to DARTS as a transcriber user
   When I click on the "Search" link
-  And I set "Case ID" to "A{{seq}}006"
+  And I set "Case ID" to "B{{seq}}006"
   And I press the "Search" button
-  And I click on "A{{seq}}006" in the same row as "Harrow Crown Court"
+  And I click on "B{{seq}}006" in the same row as "Harrow Crown Court"
   And I click on "{{displaydate}}" in the same row as "{{seq}}-6"
   Then I see "{{seq}}ABC-6" on the page
 
@@ -255,9 +255,9 @@ Scenario: Request Audio by setting Start Time and End Time
 
   Then I see "Confirm your Order" on the page
   And I see "Case details" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "Audio details" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
@@ -267,9 +267,9 @@ Scenario: Request Audio by setting Start Time and End Time
 
   When I press the "Confirm" button
   Then I see "Your order is complete" on the page
-  And I see "A{{seq}}006" on the page
+  And I see "B{{seq}}006" on the page
   And I see "Harrow Crown Court" on the page
-  And I see "Def {{seq}}-1" on the page
+  And I see "Def {{seq}}-6" on the page
   And I see "{{displaydate}}" on the page
   And I see "10:01:00" on the page
   And I see "10:02:00" on the page


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Fixes after reviewing nightly run fails:
- Audio data creation now starts with B{{seq}} rather than A{{seq}} which caused them to clash when searching for them via case search.
- Commented out "When I authenticate from the darmidtier source system" temporarily while we figure out what went wrong with it. Can rerun with it uncommented after.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
