### PR TITLE
DMP 1941: Create dynatrace panel to show CPP poll check

### DIFF
--- a/src/test/resources/cucumber/features/SoapApi/DARTS_Events.feature
+++ b/src/test/resources/cucumber/features/SoapApi/DARTS_Events.feature
@@ -759,3 +759,14 @@ Examples:
   | Harrow Crown Court | Room {{seq}} | T{{seq}}208 | {{timestamp-10:00:00}} | {{seq}}450 | {{seq}}1450 | 1000   | 1001    | text {{seq}}E |               |               | Offences put to defendant                                                                                                              |       |
 
 
+  @EVENT_API @SOAP_EVENT @regression @DMP-1941
+  Scenario Outline: Create Poll Check events
+  These tests will help populate the relevant section of the DARTS Dynatrace Dashboard each time they are executed
+  NB: The usual 'Then' step is missing as the 'When' step includes the assertion of the API response code
+    Given I authenticate from the <source> source system
+    When  I create an event
+      | message_id  | type   | sub_type  | event_id  | courthouse   | courtroom   | case_numbers  | event_text  | date_time  | case_retention_fixed_policy | case_total_sentence |
+      | <msgId>     | <type> | <subType> | <eventId> | <courthouse> | <courtroom> | <caseNumbers> | <eventText> | <dateTime> | <caseRetention>             | <totalSentence>     |
+    Examples:
+      | source | courthouse         | courtroom    | caseNumbers     | dateTime               | msgId        | eventId       | type   | subType | eventText      | caseRetention | totalSentence |
+      | CPP    | Harrow Crown Court | Room {{seq}} | T{{seq}}2070501 | {{timestamp-10:01:01}} | {{seq}}20705 | -{{seq}}20705 | 20705  |         | CPP Daily Test |               |               |

--- a/src/test/resources/testdata.properties
+++ b/src/test/resources/testdata.properties
@@ -1,6 +1,6 @@
 #values to substitute in scenarios
 #Tue Jun 11 13:31:25 BST 2024
-=\=\=\=\=\=\=
+#=================================
 demo_courthouse1=Swansea
 demo_courthouse2=Bath
 seq=339


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-1941 


### Change description ###
Add in an automated test scenario for CPP Poll Check messages into the DARTS_Events.feature file. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
