### PR TITLE
DMP-3295: CPP Poll Check Dynatrace Dashboard Panel not displaying poll check when timestamp has "00" seconds

### DIFF
--- a/src/test/resources/cucumber/features/SoapApi/DARTS_Events.feature
+++ b/src/test/resources/cucumber/features/SoapApi/DARTS_Events.feature
@@ -836,15 +836,15 @@ Examples:
   | Harrow Crown Court | Room {{seq}}A | Room {{seq}}B | T{{seq}}258 | {{timestamp-10:00:00}} | {{seq}}450 | {{seq}}1450 | 1000   | 1001    | text {{seq}}E |               |               | Offences put to defendant                                                                                                              |       |
 
 
-  @EVENT_API @SOAP_EVENT @regression @DMP-1941 @DMP-1928
-  Scenario Outline: Create Poll Check events
-  These tests will help populate the relevant section of the DARTS Dynatrace Dashboard each time they are executed
-  NB: The usual 'Then' step is missing as the 'When' step includes the assertion of the API response code
-    Given I authenticate from the <source> source system
-    When  I create an event
-      | message_id  | type   | sub_type  | event_id  | courthouse   | courtroom   | case_numbers  | event_text  | date_time  | case_retention_fixed_policy | case_total_sentence |
-      | <msgId>     | <type> | <subType> | <eventId> | <courthouse> | <courtroom> | <caseNumbers> | <eventText> | <dateTime> | <caseRetention>             | <totalSentence>     |
-    Examples:
-      | source | courthouse         | courtroom    | caseNumbers     | dateTime               | msgId        | eventId       | type   | subType | eventText      | caseRetention | totalSentence |
-      | CPP    | Harrow Crown Court | Room {{seq}} | T{{seq}}2070501 | {{timestamp-10:01:01}} | {{seq}}20705 | -{{seq}}20705 | 20705  |         | CPP Daily Test |               |               |
-      | XHIBIT | Harrow Crown Court | Room {{seq}} | T{{seq}}2070501 | {{timestamp-10:02:02}} | {{seq}}20705 | {{seq}}20705  | 20705  |         | Xhibit Daily Test |               |               |
+@EVENT_API @SOAP_EVENT @regression @DMP-1941 @DMP-1928
+Scenario Outline: Create Poll Check events
+These tests will help populate the relevant section of the DARTS Dynatrace Dashboard each time they are executed
+NB: The usual 'Then' step is missing as the 'When' step includes the assertion of the API response code
+  Given I authenticate from the <source> source system
+  When  I create an event
+    | message_id  | type   | sub_type  | event_id  | courthouse   | courtroom   | case_numbers  | event_text  | date_time  | case_retention_fixed_policy | case_total_sentence |
+    | <msgId>     | <type> | <subType> | <eventId> | <courthouse> | <courtroom> | <caseNumbers> | <eventText> | <dateTime> | <caseRetention>             | <totalSentence>     |
+  Examples:
+    | source | courthouse         | courtroom    | caseNumbers     | dateTime               | msgId        | eventId       | type   | subType | eventText         | caseRetention | totalSentence |
+    | CPP    | Harrow Crown Court | Room {{seq}} | T{{seq}}2070501 | {{timestamp-10:00:00}} | {{seq}}20705 | -{{seq}}20705 | 20705  |         | CPP Daily Test    |               |               |
+    | XHIBIT | Harrow Crown Court | Room {{seq}} | T{{seq}}2070501 | {{timestamp-10:01:01}} | {{seq}}20705 | {{seq}}20705  | 20705  |         | Xhibit Daily Test |               |               |

--- a/src/test/resources/testdata.properties
+++ b/src/test/resources/testdata.properties
@@ -1,7 +1,7 @@
 #values to substitute in scenarios
-#Fri Jun 21 14:04:02 BST 2024
+#Thu Jul 04 17:19:37 BST 2024
 demo_courthouse1=Swansea
 demo_courthouse2=Bath
-seq=340
+seq=345
 courthouse2=Nowhere
 courthouse1=Harrow Crown Court


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3295


### Change description ###
DMP-3295: Updated existing poll check test scenarios (CPP & XHIBIT) so that one of them uses a "00" seconds time stamp.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
