### PR TITLE
DMP-2798_Date-Utils-additions

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/automation/utils/DateUtils.java
+++ b/src/main/java/uk/gov/hmcts/darts/automation/utils/DateUtils.java
@@ -367,13 +367,17 @@ public class DateUtils {
 										if (subsString.startsWith("displaydate-")) {
 											substitutionString = displayDate(subsString.substring(12));
 										} else {
-											if (subsString.startsWith("utc-")) {
-												substitutionString = utcTimestamp(subsString.substring(4));
+											if (subsString.startsWith("displaydate0-")) {
+												substitutionString = displayDate0(subsString.substring(13));
 											} else {
-												if (subsString.startsWith("retention-")) {
-													substitutionString = retention(subsString.substring(10));
+												if (subsString.startsWith("utc-")) {
+													substitutionString = utcTimestamp(subsString.substring(4));
 												} else {
-													Assertions.fail("Invalid value to substitute =>" + subsString );
+													if (subsString.startsWith("retention-")) {
+														substitutionString = retention(subsString.substring(10));
+													} else {
+														Assertions.fail("Invalid value to substitute =>" + subsString );
+													}
 												}
 											}
 										}
@@ -412,6 +416,12 @@ public class DateUtils {
 		return date.format(formatter);
 	}
 	
+	public static String todayDisplay0() {
+		LocalDate date = LocalDate.now();
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy");
+		return date.format(formatter);
+	}
+	
 	public static String dateAsYyyyMmDd(String string) {
 		return datePart(string, "yyyy") + "-" + datePart(string, "mm") + "-" + datePart(string, "dd");
 	}
@@ -419,6 +429,12 @@ public class DateUtils {
 	public static String displayDate(String string) {
 		LocalDate date = LocalDate.parse(dateAsYyyyMmDd(string));
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d MMM yyyy");
+		return date.format(formatter);
+	}
+	
+	public static String displayDate0(String string) {
+		LocalDate date = LocalDate.parse(dateAsYyyyMmDd(string));
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy");
 		return date.format(formatter);
 	}
 	

--- a/src/main/java/uk/gov/hmcts/darts/automation/utils/Substitutions.java
+++ b/src/main/java/uk/gov/hmcts/darts/automation/utils/Substitutions.java
@@ -61,7 +61,8 @@ public class Substitutions {
 			if (subsString.startsWith("date") || subsString.startsWith("numdate") ||
 					subsString.startsWith("dd-") || subsString.startsWith("mm-") ||
 					subsString.startsWith("yyyy-") || subsString.startsWith("yyyymmdd") ||
-					subsString.startsWith("timestamp-") || subsString.startsWith("displaydate-") ||
+					subsString.startsWith("timestamp-") || subsString.startsWith("displaydate-") || 
+					subsString.startsWith("displaydate0-") ||
 					subsString.startsWith("utc-") || subsString.startsWith("retention-")) {
 				substitutionString = DateUtils.substituteDateValue(subsString);
 			} else {
@@ -74,13 +75,17 @@ public class Substitutions {
 						if (subsString.equalsIgnoreCase("displaydate")) {
 							substitutionString = DateUtils.todayDisplay();
 						} else {
-							if (subsString.startsWith("mac-address-")) {
-								substitutionString = macAddress(subsTag.substring(12));
+							if (subsString.equalsIgnoreCase("displaydate0")) {
+								substitutionString = DateUtils.todayDisplay0();
 							} else {
-								if (subsString.startsWith("ip-address-")) {
-									substitutionString = ipAddress(subsTag.substring(11));
+								if (subsString.startsWith("mac-address-")) {
+									substitutionString = macAddress(subsTag.substring(12));
 								} else {
-									substitutionString = TestData.getProperty(subsTag);
+									if (subsString.startsWith("ip-address-")) {
+										substitutionString = ipAddress(subsTag.substring(11));
+									} else {
+										substitutionString = TestData.getProperty(subsTag);
+									}
 								}
 							}
 						}
@@ -152,6 +157,8 @@ public class Substitutions {
 		System.out.println(substituteValue("{{displayDate-{{date+7 years}}}}"));
 		Assertions.assertEquals("12", substituteValue("{{dd-12/34/5678}}"));
 		Assertions.assertEquals("9 Dec 2023", substituteValue("{{displaydate-09-12-2023}}"));
+		System.out.println(substituteValue("{{displaydate-{{date+99years}}}}"));
+		System.out.println(substituteValue("{{displaydate0-{{date+99years}}}}"));
 	}
 	
 	@Test

--- a/src/test/resources/cucumber/features/portal/DARTS_Case_Retention.feature
+++ b/src/test/resources/cucumber/features/portal/DARTS_Case_Retention.feature
@@ -104,11 +104,11 @@ Feature: Case Retention
     And I see "<case_number>" in the same row as "Case ID"
     And I see "Harrow Crown Court" in the same row as "Courthouse"
     And I see "Change case retention date" on the page
-    And I see "{{displaydate(date+99years)}} (Permanent)" in the same row as "Retain case until"
+    And I see "{{displaydate0{{date+99years}}}} (Permanent)" in the same row as "Retain case until"
     And I see "AC5 99 Years Permanent Retention" in the same row as "Reason for change"
     And I press the "Confirm retention date change" button
     Then I see "Case retention date changed." on the page
-    And I see "{{displaydate(date+99years)}}" in the same row as "Retain case until"
+    And I see "{{displaydate0{{date+99years}}}}" in the same row as "Retain case until"
 
     #DMP-2161-AC4 Valid specific date
     And I click on the "Change retention date" link
@@ -256,7 +256,7 @@ Feature: Case Retention
 
     When I press the "Confirm retention date change" button
     Then I see "Case retention date changed." on the page
-    And I see "{{displaydate}}" in the same row as "Date applied"
+    And I see "{{displaydate0}}" in the same row as "Date applied"
     Then I verify the HTML table "Retention audit history" contains the following values
       | Date retention changed | Retention date | Amended by   | Retention policy | Comments                                            | Status   |
       | *NO-CHECK*             | *NO-CHECK*     | *NO-CHECK*   | Custodial        |                                                     | COMPLETE |
@@ -291,7 +291,7 @@ Feature: Case Retention
     Then I see "Case retention date changed." on the page
     And I see "R{{seq}}AB11" in the same row as "Case ID"
     And I see "Harrow Crown Court" in the same row as "Courthouse"
-    And I see "{{displaydate}}" in the same row as "Date applied"
+    And I see "{{displaydate0}}" in the same row as "Date applied"
     Then I verify the HTML table "Retention audit history" contains the following values
       | Date retention changed | Retention date | Amended by   | Retention policy | Comments                                            | Status   |
       | *NO-CHECK*             | *NO-CHECK*     | *NO-CHECK*   | Custodial        |                                                     | COMPLETE |
@@ -313,7 +313,7 @@ Feature: Case Retention
 
     When I press the "Confirm retention date change" button
     Then I see "Case retention date changed." on the page
-    And I see "{{displaydate}}" in the same row as "Date applied"
+    And I see "{{displaydate0}}" in the same row as "Date applied"
     And I see "DARTS Permanent Policy" in the same row as "DARTS Retention policy applied"
     Then I verify the HTML table "Retention audit history" contains the following values
       | Date retention changed | Retention date | Amended by   | Retention policy | Comments                                            | Status   |


### PR DESCRIPTION
### JIRA link (if applicable) ###
DMP-2798


### Change description ###
Added {{displaydate0}} to substitutions available to generate current date in 01 Jul 2024 format 
Updated CaseRetention feature to use new formats

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
